### PR TITLE
Add some logging to private forwarder

### DIFF
--- a/src/main/java/org/enginehub/discord/module/PrivateForwarding.java
+++ b/src/main/java/org/enginehub/discord/module/PrivateForwarding.java
@@ -77,14 +77,20 @@ public class PrivateForwarding extends ListenerAdapter implements Module {
                     return;
                 }
 
+                System.err.println("Forwarding DM from " + user.getAsTag() + " (" + user.getId() + ") with message "
+                    + event.getMessage().getContentRaw()
+                    + " (attachments: " + event.getMessage().getAttachments() + ")");
+
                 EmbedBuilder builder = createEmbed()
-                    .setAuthor(user.getAsTag(),
+                    .setAuthor(
+                        user.getAsTag(),
                         "https://discord.com/channels/@me/" + user.getId(),
                         user.getEffectiveAvatarUrl()
                     )
                     .setDescription(event.getMessage().getContentRaw())
                     .setTimestamp(event.getMessage().getTimeCreated())
-                    .setFooter("Sent to " + event.getChannel().getUser().getAsTag());
+                    .setFooter("In DM " + event.getChannel().getUser().getAsTag()
+                        + " (" + event.getChannel().getUser().getId() + ")");
 
                 event.getMessage().getAttachments().forEach(att -> builder.addField(att.getFileName(), att.getUrl(), false));
 


### PR DESCRIPTION
Not sure what the root cause is for the bug, but this should help figure out what's wrong. Want to run it by maddy before I deploy it.