### PR TITLE
Add message spam filter

### DIFF
--- a/src/main/java/org/enginehub/discord/EngineHubBot.java
+++ b/src/main/java/org/enginehub/discord/EngineHubBot.java
@@ -47,7 +47,8 @@ import org.enginehub.discord.module.IdleRPG;
 import org.enginehub.discord.module.JoinMessage;
 import org.enginehub.discord.module.LinkGrabber;
 import org.enginehub.discord.module.Module;
-import org.enginehub.discord.module.NoSpam;
+import org.enginehub.discord.module.NoMessageSpam;
+import org.enginehub.discord.module.NoPingSpam;
 import org.enginehub.discord.module.PingWarning;
 import org.enginehub.discord.module.PrivateForwarding;
 import org.enginehub.discord.module.RoryFetch;
@@ -195,7 +196,8 @@ public class EngineHubBot implements Runnable, EventListener {
             new Alerts(),
             new ChatFilter(),
             new SetProfilePicture(),
-            new NoSpam(),
+            new NoPingSpam(),
+            new NoMessageSpam(),
             new ErrorHelper(),
             new LinkGrabber(),
             new JoinMessage(),

--- a/src/main/java/org/enginehub/discord/module/NoMessageSpam.java
+++ b/src/main/java/org/enginehub/discord/module/NoMessageSpam.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) EngineHub and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.enginehub.discord.module;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.enginehub.discord.EngineHubBot;
+import org.enginehub.discord.util.PermissionRoles;
+import org.enginehub.discord.util.PunishmentUtil;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A simple anti-same-message spam filter.
+ */
+public class NoMessageSpam extends ListenerAdapter implements Module {
+
+    private final class CacheKey {
+        final long userId;
+        final int messageHash;
+
+        private CacheKey(long userId, int messageHash) {
+            this.userId = userId;
+            this.messageHash = messageHash;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            CacheKey cacheKey = (CacheKey) o;
+            return userId == cacheKey.userId && messageHash == cacheKey.messageHash;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(userId, messageHash);
+        }
+    }
+
+    // Track messages from a user for the last 10 minutes.
+    private final LoadingCache<CacheKey, AtomicInteger> messageCounts = CacheBuilder.newBuilder()
+        .expireAfterAccess(10, TimeUnit.MINUTES)
+        .build(CacheLoader.from(() -> new AtomicInteger(0)));
+
+    @Override
+    public void onGuildMessageReceived(@Nonnull GuildMessageReceivedEvent event) {
+        // Don't check for people who are trusted not to spam
+        if (EngineHubBot.isAuthorised(event.getMember(), PermissionRoles.TRUSTED)) {
+            return;
+        }
+
+        var cacheKey = new CacheKey(
+            event.getAuthor().getIdLong(),
+            event.getMessage().getContentRaw().hashCode()
+        );
+        var hashCount = messageCounts.getUnchecked(cacheKey).incrementAndGet();
+
+        // We only want one thread to run this, so use an exact equality to ensure this
+        if (hashCount == 6) {
+            PunishmentUtil.banUser(event.getGuild(), event.getAuthor(), "Message spam", true);
+        }
+    }
+}

--- a/src/main/java/org/enginehub/discord/module/NoPingSpam.java
+++ b/src/main/java/org/enginehub/discord/module/NoPingSpam.java
@@ -32,7 +32,7 @@ import java.util.HashMap;
 
 import javax.annotation.Nonnull;
 
-public class NoSpam extends ListenerAdapter implements Module {
+public class NoPingSpam extends ListenerAdapter implements Module {
 
     private final HashMap<String, Integer> spamTimes = new HashMap<>();
 

--- a/src/main/java/org/enginehub/discord/util/PunishmentUtil.java
+++ b/src/main/java/org/enginehub/discord/util/PunishmentUtil.java
@@ -35,14 +35,16 @@ public class PunishmentUtil {
     public static void kickUser(Guild guild, Member member, String reason) {
         member.getUser().openPrivateChannel().queue((privateChannel ->
                 privateChannel.sendMessage("You have been kicked for `" + reason + "`. " + getContactString())
-                .queue(message -> guild.kick(member, reason).queue())
+                    .queue()
         ));
+        guild.kick(member, reason).queue();
     }
 
     public static void banUser(Guild guild, User user, String reason, boolean eraseHistory) {
         user.openPrivateChannel().queue((privateChannel ->
                 privateChannel.sendMessage("You have been banned for `" + reason + "`. " + getContactString())
-                .queue(message -> guild.ban(user, eraseHistory ? 7 : 0, "[Bot Ban] " + reason).queue())
+                .queue()
         ));
+        guild.ban(user, eraseHistory ? 1 : 0, "[Bot Ban] " + reason).queue();
     }
 }

--- a/src/main/java/org/enginehub/discord/util/PunishmentUtil.java
+++ b/src/main/java/org/enginehub/discord/util/PunishmentUtil.java
@@ -33,18 +33,20 @@ public class PunishmentUtil {
     }
 
     public static void kickUser(Guild guild, Member member, String reason) {
-        member.getUser().openPrivateChannel().queue((privateChannel ->
+        member.getUser().openPrivateChannel().submit()
+            .thenCompose(privateChannel ->
                 privateChannel.sendMessage("You have been kicked for `" + reason + "`. " + getContactString())
-                .queue()
-        ));
-        guild.kick(member, reason).queue();
+                    .submit()
+            )
+            .whenComplete((v, ex) -> guild.kick(member, reason).queue());
     }
 
     public static void banUser(Guild guild, User user, String reason, boolean eraseHistory) {
-        user.openPrivateChannel().queue((privateChannel ->
+        user.openPrivateChannel().submit()
+            .thenCompose(privateChannel ->
                 privateChannel.sendMessage("You have been banned for `" + reason + "`. " + getContactString())
-                .queue()
-        ));
-        guild.ban(user, eraseHistory ? 1 : 0, "[Bot Ban] " + reason).queue();
+                    .submit()
+            )
+            .whenComplete((v, ex) -> guild.ban(user, eraseHistory ? 1 : 0, "[Bot Ban] " + reason).queue());
     }
 }

--- a/src/main/java/org/enginehub/discord/util/PunishmentUtil.java
+++ b/src/main/java/org/enginehub/discord/util/PunishmentUtil.java
@@ -35,7 +35,7 @@ public class PunishmentUtil {
     public static void kickUser(Guild guild, Member member, String reason) {
         member.getUser().openPrivateChannel().queue((privateChannel ->
                 privateChannel.sendMessage("You have been kicked for `" + reason + "`. " + getContactString())
-                    .queue()
+                .queue()
         ));
         guild.kick(member, reason).queue();
     }


### PR DESCRIPTION
This prevents simple repeated spam from needing manual clean-up. More complex varied messages can of course bypass this filter, but hey, whatever.

I've also lowered the history deletion to only 1 day, to preserve as much as possible, as well as making the kick/ban not dependent on message sending, which may or may not fail if DMs are closed off.