### PR TITLE
Add pagination for leaderboard command

### DIFF
--- a/src/main/java/org/enginehub/discord/module/IdleRPG.java
+++ b/src/main/java/org/enginehub/discord/module/IdleRPG.java
@@ -33,6 +33,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Maps;
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.enginehub.discord.util.BigMath;
@@ -98,10 +99,10 @@ public class IdleRPG extends ListenerAdapter implements Module {
         return data.getLevelTime().plus(getXpForLevelUp(data.getLevel() + 1));
     }
 
-    private PlayerData getPlayerData(@Nonnull MessageReceivedEvent event) {
+    private PlayerData getPlayerData(User author) {
         return players.computeIfAbsent(
-            event.getAuthor().getIdLong(),
-            _l -> new PlayerData(Instant.EPOCH, 0, event.getAuthor().getName())
+                author.getIdLong(),
+            _l -> new PlayerData(Instant.EPOCH, 0, author.getName())
         );
     }
 
@@ -117,7 +118,7 @@ public class IdleRPG extends ListenerAdapter implements Module {
     }
 
     private void tryLevelUpgrade(@Nonnull MessageReceivedEvent event) {
-        PlayerData data = getPlayerData(event);
+        PlayerData data = getPlayerData(event.getAuthor());
         var now = Instant.now();
         var levelUpTime = getLevelUpInstant(data);
         if (now.isAfter(levelUpTime)) {

--- a/src/main/java/org/enginehub/discord/module/IdleRPG.java
+++ b/src/main/java/org/enginehub/discord/module/IdleRPG.java
@@ -98,74 +98,102 @@ public class IdleRPG extends ListenerAdapter implements Module {
         return data.getLevelTime().plus(getXpForLevelUp(data.getLevel() + 1));
     }
 
+    private PlayerData getPlayerData(@Nonnull MessageReceivedEvent event) {
+        return players.computeIfAbsent(
+            event.getAuthor().getIdLong(),
+            _l -> new PlayerData(Instant.EPOCH, 0, event.getAuthor().getName())
+        );
+    }
+
     @Override
     public void onMessageReceived(@Nonnull MessageReceivedEvent event) {
+        String[] commandArguments = event.getMessage().getContentRaw().split(" ");
         if (Objects.equals(event.getMessage().getContentRaw(), IDLE_RPG_TOKEN)) {
-            PlayerData data = players.computeIfAbsent(
-                event.getAuthor().getIdLong(),
-                _l -> new PlayerData(Instant.EPOCH, 0, event.getAuthor().getName())
-            );
-            var now = Instant.now();
-            var levelUpTime = getLevelUpInstant(data);
-            if (now.isAfter(levelUpTime)) {
-                var postLevelUp = data.applyLevelUp(now, event.getAuthor().getName());
-                EmbedBuilder builder = createEmbed();
-                builder.setAuthor("IdleRPG");
-                builder.appendDescription(event.getAuthor().getAsMention()
-                    + " LEVEL UP! You are now level "
-                    + postLevelUp.getLevel()
-                    + '!'
-                );
+            tryLevelUpgrade(event);
+        } else if ((commandArguments.length == 1 || commandArguments.length == 2)
+                && Objects.equals(commandArguments[0], IDLE_RPG_LEADERBOARD_TOKEN)) {
+            listLeaderboard(event, commandArguments);
+        }
+    }
 
-                event.getChannel().sendMessage(builder.build()).queue();
-                players.put(event.getAuthor().getIdLong(), postLevelUp);
-                isDirty = true;
-            } else {
-                var durationUntil = Duration.between(now, levelUpTime);
-                var fullDuration = Duration.between(data.getLevelTime(), levelUpTime);
-                var percentRemaining = BigDecimal.valueOf(fullDuration.minus(durationUntil).toMillis())
-                    .divide(BigDecimal.valueOf(fullDuration.toMillis()), MathContext.DECIMAL128)
-                    .multiply(BigDecimal.valueOf(100))
-                    .setScale(2, RoundingMode.DOWN);
+    private void tryLevelUpgrade(@NotNull MessageReceivedEvent event) {
+        PlayerData data = getPlayerData(event);
+        var now = Instant.now();
+        var levelUpTime = getLevelUpInstant(data);
+        if (now.isAfter(levelUpTime)) {
+            var postLevelUp = data.applyLevelUp(now, event.getAuthor().getName());
+            EmbedBuilder builder = createEmbed();
+            builder.setAuthor("IdleRPG");
+            builder.appendDescription(event.getAuthor().getAsMention()
+                + " LEVEL UP! You are now level "
+                + postLevelUp.getLevel()
+                + '!'
+            );
+
+            event.getChannel().sendMessage(builder.build()).queue();
+            players.put(event.getAuthor().getIdLong(), postLevelUp);
+            isDirty = true;
+        } else {
+            var durationUntil = Duration.between(now, levelUpTime);
+            var fullDuration = Duration.between(data.getLevelTime(), levelUpTime);
+            var percentRemaining = BigDecimal.valueOf(fullDuration.minus(durationUntil).toMillis())
+                .divide(BigDecimal.valueOf(fullDuration.toMillis()), MathContext.DECIMAL128)
+                .multiply(BigDecimal.valueOf(100))
+                .setScale(2, RoundingMode.DOWN);
+            EmbedBuilder builder = createEmbed();
+            builder.setAuthor("IdleRPG");
+            builder.appendDescription(
+                event.getAuthor().getAsMention()
+                    + " you're "
+                    + PERCENTAGE_FORMAT.format(percentRemaining)
+                    + "% of the way there! "
+                    + StringUtil.formatDurationHumanReadable(durationUntil));
+            event.getChannel().sendMessage(builder.build()).queue();
+        }
+    }
+
+    private void listLeaderboard(@NotNull MessageReceivedEvent event, String[] commandArguments) {
+        int page = 1;
+        if (commandArguments.length == 2) {
+            try {
+                page = Integer.parseUnsignedInt(commandArguments[1]);
+            } catch (NumberFormatException e) {
                 EmbedBuilder builder = createEmbed();
                 builder.setAuthor("IdleRPG");
                 builder.appendDescription(
                     event.getAuthor().getAsMention()
-                        + " you're "
-                        + PERCENTAGE_FORMAT.format(percentRemaining)
-                        + "% of the way there! "
-                        + StringUtil.formatDurationHumanReadable(durationUntil));
+                        + " that's not a valid page number!");
                 event.getChannel().sendMessage(builder.build()).queue();
             }
-        } else if (Objects.equals(event.getMessage().getContentRaw(), IDLE_RPG_LEADERBOARD_TOKEN)) {
-            List<PlayerData> topPlayers = players.values()
-                .stream()
-                .sorted(Comparator.<PlayerData>naturalOrder().reversed())
-                .limit(10)
-                .collect(Collectors.toList());
-            var now = Instant.now();
-            StringBuilder leaderboardMessage = new StringBuilder("IdleRPG Leaderboard\n\n");
-            for (int i = 0; i < topPlayers.size(); i++) {
-                PlayerData data = topPlayers.get(i);
-                boolean canLevelUp = now.isAfter(getLevelUpInstant(data));
-                leaderboardMessage
-                    .append('#')
-                    .append(i + 1)
-                    .append(' ')
-                    .append(data.getLastName())
-                    .append(": Level ")
-                    .append(data.getLevel())
-                    .append(canLevelUp ? '*' : ' ')
-                    .append('\n');
-            }
-            leaderboardMessage.append("\n(Showing ").append(topPlayers.size()).append(" out of ").append(players.size()).append(')');
-
-            EmbedBuilder builder = createEmbed();
-            builder.setAuthor("IdleRPG");
-            builder.appendDescription(leaderboardMessage.toString());
-
-            event.getChannel().sendMessage(builder.build()).queue();
         }
+        List<PlayerData> topPlayers = players.values()
+            .stream()
+            .sorted(Comparator.<PlayerData>naturalOrder().reversed())
+            .limit(10)
+            .skip((page - 1) * 10L)
+            .collect(Collectors.toList());
+        var now = Instant.now();
+        StringBuilder leaderboardMessage = new StringBuilder("IdleRPG Leaderboard (Page " + page + ")\n\n");
+        for (int i = 0; i < topPlayers.size(); i++) {
+            PlayerData data = topPlayers.get(i);
+            boolean canLevelUp = now.isAfter(getLevelUpInstant(data));
+            leaderboardMessage
+                .append('#')
+                .append(i + 1)
+                .append(' ')
+                .append(data.getLastName())
+                .append(": Level ")
+                .append(data.getLevel())
+                .append(canLevelUp ? '*' : ' ')
+                .append('\n');
+        }
+        leaderboardMessage.append("\n(Showing ").append(topPlayers.size()).append(" out of ").append(players.size()).append(')');
+
+        EmbedBuilder builder = createEmbed();
+        builder.setAuthor("IdleRPG");
+        builder.appendDescription(leaderboardMessage.toString());
+
+        event.getChannel().sendMessage(builder.build()).queue();
     }
 
     @Override

--- a/src/main/java/org/enginehub/discord/module/IdleRPG.java
+++ b/src/main/java/org/enginehub/discord/module/IdleRPG.java
@@ -165,6 +165,7 @@ public class IdleRPG extends ListenerAdapter implements Module {
                     event.getAuthor().getAsMention()
                         + " that's not a valid page number!");
                 event.getChannel().sendMessage(builder.build()).queue();
+                return;
             }
         }
         List<PlayerData> topPlayers = players.values()

--- a/src/main/java/org/enginehub/discord/module/IdleRPG.java
+++ b/src/main/java/org/enginehub/discord/module/IdleRPG.java
@@ -116,7 +116,7 @@ public class IdleRPG extends ListenerAdapter implements Module {
         }
     }
 
-    private void tryLevelUpgrade(@NotNull MessageReceivedEvent event) {
+    private void tryLevelUpgrade(@Nonnull MessageReceivedEvent event) {
         PlayerData data = getPlayerData(event);
         var now = Instant.now();
         var levelUpTime = getLevelUpInstant(data);
@@ -152,11 +152,12 @@ public class IdleRPG extends ListenerAdapter implements Module {
         }
     }
 
-    private void listLeaderboard(@NotNull MessageReceivedEvent event, String[] commandArguments) {
+    private void listLeaderboard(@Nonnull MessageReceivedEvent event, String[] commandArguments) {
         int page = 1;
         if (commandArguments.length == 2) {
             try {
                 page = Integer.parseUnsignedInt(commandArguments[1]);
+                if (page == 0) throw new NumberFormatException();
             } catch (NumberFormatException e) {
                 EmbedBuilder builder = createEmbed();
                 builder.setAuthor("IdleRPG");


### PR DESCRIPTION
I added pagination to the leaderboard command. It's accesible with the syntax:
`>l <page>`

~The next step is to setup some test server to test the changes.~
Should work fine now.