### PR TITLE
Migrate permission roles to an enum

### DIFF
--- a/src/main/java/org/enginehub/discord/module/Alerts.java
+++ b/src/main/java/org/enginehub/discord/module/Alerts.java
@@ -32,7 +32,7 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import ninja.leaping.configurate.ConfigurationNode;
 import org.enginehub.discord.EngineHubBot;
 import org.enginehub.discord.Settings;
-import org.enginehub.discord.util.PermissionRoles;
+import org.enginehub.discord.util.PermissionRole;
 import org.enginehub.discord.util.PunishmentUtil;
 import org.enginehub.discord.util.command.CommandPermission;
 import org.enginehub.discord.util.command.CommandPermissionConditionGenerator;
@@ -114,7 +114,7 @@ public class Alerts extends ListenerAdapter implements Module {
     }
 
     @Command(name = "alert", desc = "Sets the channel to alert.")
-    @CommandPermission(PermissionRoles.ADMIN)
+    @CommandPermission(PermissionRole.ADMIN)
     public void alert(Message message) {
         alertChannels.put(message.getGuild().getId(), message.getChannel().getId());
         message.getChannel().sendMessage("Set alert channel!").queue();

--- a/src/main/java/org/enginehub/discord/module/ChatFilter.java
+++ b/src/main/java/org/enginehub/discord/module/ChatFilter.java
@@ -22,7 +22,7 @@
 package org.enginehub.discord.module;
 
 import org.enginehub.discord.EngineHubBot;
-import org.enginehub.discord.util.PermissionRoles;
+import org.enginehub.discord.util.PermissionRole;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
@@ -38,7 +38,7 @@ public class ChatFilter extends ListenerAdapter implements Module {
     @Override
     public void onMessageReceived(@Nonnull MessageReceivedEvent event) {
         // Don't check for people who are allowed to send invites
-        if (EngineHubBot.isAuthorised(event.getMember(), PermissionRoles.TRUSTED)) {
+        if (EngineHubBot.isAuthorised(event.getMember(), PermissionRole.TRUSTED)) {
             return;
         }
 

--- a/src/main/java/org/enginehub/discord/module/LinkGrabber.java
+++ b/src/main/java/org/enginehub/discord/module/LinkGrabber.java
@@ -27,7 +27,7 @@ import net.dv8tion.jda.api.entities.User;
 import ninja.leaping.configurate.ConfigurationNode;
 import org.apache.commons.text.similarity.LevenshteinDistance;
 import org.enginehub.discord.Settings;
-import org.enginehub.discord.util.PermissionRoles;
+import org.enginehub.discord.util.PermissionRole;
 import org.enginehub.discord.util.command.CommandPermission;
 import org.enginehub.discord.util.command.CommandPermissionConditionGenerator;
 import org.enginehub.discord.util.command.CommandRegistrationHandler;
@@ -95,7 +95,7 @@ public class LinkGrabber implements Module {
     }
 
     @Command(name = "addalias", aliases = {"addlink"}, desc = "Adds an alias.")
-    @CommandPermission(PermissionRoles.MODERATOR)
+    @CommandPermission(PermissionRole.MODERATOR)
     public void addLink(Message message, @Arg(desc = "The alias key") String key, @Arg(desc = "The alias value", variable = true) List<String> link) {
         aliasMap.put(key, String.join(" ", link).replace("\\n", "\n"));
 

--- a/src/main/java/org/enginehub/discord/module/NoMessageSpam.java
+++ b/src/main/java/org/enginehub/discord/module/NoMessageSpam.java
@@ -33,7 +33,7 @@ import ninja.leaping.configurate.ConfigurationNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.enginehub.discord.EngineHubBot;
-import org.enginehub.discord.util.PermissionRoles;
+import org.enginehub.discord.util.PermissionRole;
 import org.enginehub.discord.util.PunishmentUtil;
 import org.jetbrains.annotations.NotNull;
 
@@ -63,7 +63,7 @@ public class NoMessageSpam extends ListenerAdapter implements Module {
     @Override
     public void onMessageReceived(@Nonnull MessageReceivedEvent event) {
         // Don't check for people who are trusted not to spam
-        if (EngineHubBot.isAuthorised(event.getMember(), PermissionRoles.TRUSTED)) {
+        if (EngineHubBot.isAuthorised(event.getMember(), PermissionRole.TRUSTED)) {
             return;
         }
 

--- a/src/main/java/org/enginehub/discord/module/NoPingSpam.java
+++ b/src/main/java/org/enginehub/discord/module/NoPingSpam.java
@@ -23,7 +23,7 @@ package org.enginehub.discord.module;
 
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import org.enginehub.discord.EngineHubBot;
-import org.enginehub.discord.util.PermissionRoles;
+import org.enginehub.discord.util.PermissionRole;
 import org.enginehub.discord.util.PunishmentUtil;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -39,7 +39,7 @@ public class NoPingSpam extends ListenerAdapter implements Module {
     @Override
     public void onMessageReceived(@Nonnull MessageReceivedEvent event) {
         // Don't check for people who are allowed to ping
-        if (EngineHubBot.isAuthorised(event.getMember(), PermissionRoles.TRUSTED)) {
+        if (EngineHubBot.isAuthorised(event.getMember(), PermissionRole.TRUSTED)) {
             return;
         }
 

--- a/src/main/java/org/enginehub/discord/module/PingWarning.java
+++ b/src/main/java/org/enginehub/discord/module/PingWarning.java
@@ -25,7 +25,7 @@ import net.dv8tion.jda.api.entities.GuildChannel;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.enginehub.discord.EngineHubBot;
-import org.enginehub.discord.util.PermissionRoles;
+import org.enginehub.discord.util.PermissionRole;
 import org.enginehub.discord.util.PunishmentUtil;
 
 import java.util.HashMap;
@@ -38,7 +38,7 @@ public class PingWarning extends ListenerAdapter implements Module {
     @Override
     public void onMessageReceived(@Nonnull MessageReceivedEvent event) {
         // Don't check for people who are allowed to ping
-        if (EngineHubBot.isAuthorised(event.getMember(), PermissionRoles.TRUSTED) || event.getMember() == null) {
+        if (EngineHubBot.isAuthorised(event.getMember(), PermissionRole.TRUSTED) || event.getMember() == null) {
             return;
         }
 
@@ -48,7 +48,7 @@ public class PingWarning extends ListenerAdapter implements Module {
 
         boolean mentionsDev = event.getMessage().getMentionedMembers()
                 .stream()
-                .anyMatch(user -> EngineHubBot.isAuthorised(user, PermissionRoles.MODERATOR) || EngineHubBot.isAuthorised(user, "Contributor"));
+                .anyMatch(user -> EngineHubBot.isAuthorised(user, PermissionRole.PING_EXEMPT));
 
         if (mentionsDev) {
             event.getChannel().sendMessage("Hey " + event.getAuthor().getAsMention() + "! It's against the rules to ping the developers (replies count too, unless you turn it off!), make sure to read the rules!").queue();

--- a/src/main/java/org/enginehub/discord/module/PrivateForwarding.java
+++ b/src/main/java/org/enginehub/discord/module/PrivateForwarding.java
@@ -32,7 +32,7 @@ import ninja.leaping.configurate.ConfigurationNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.enginehub.discord.EngineHubBot;
-import org.enginehub.discord.util.PermissionRoles;
+import org.enginehub.discord.util.PermissionRole;
 import org.enginehub.discord.util.command.CommandPermission;
 import org.enginehub.discord.util.command.CommandPermissionConditionGenerator;
 import org.enginehub.discord.util.command.CommandRegistrationHandler;
@@ -67,7 +67,7 @@ public class PrivateForwarding extends ListenerAdapter implements Module {
     }
 
     @Command(name = "replydm", desc = "Manually reply to a DM to the bot.")
-    @CommandPermission(PermissionRoles.MODERATOR)
+    @CommandPermission(PermissionRole.MODERATOR)
     public void replyDM(Message message, @Arg(desc = "The user to reply to") String userId, @Arg(desc = "The response", variable = true) List<String> response) {
         User user = EngineHubBot.bot.api.getUserByTag(userId);
         if (user == null) {

--- a/src/main/java/org/enginehub/discord/module/SetProfilePicture.java
+++ b/src/main/java/org/enginehub/discord/module/SetProfilePicture.java
@@ -22,7 +22,7 @@
 package org.enginehub.discord.module;
 
 import org.enginehub.discord.EngineHubBot;
-import org.enginehub.discord.util.PermissionRoles;
+import org.enginehub.discord.util.PermissionRole;
 import net.dv8tion.jda.api.entities.Icon;
 import net.dv8tion.jda.api.entities.Message;
 import org.enginehub.discord.util.command.CommandPermission;
@@ -46,7 +46,7 @@ public class SetProfilePicture implements Module {
 
 
     @Command(name = "setprofilepicture", desc = "Sets the profile picture of this bot.")
-    @CommandPermission(PermissionRoles.BOT_OWNER)
+    @CommandPermission(PermissionRole.BOT_OWNER)
     public void setProfilePicture(Message message) {
         Optional<Message.Attachment> attachmentOptional = message.getAttachments().stream().filter(Message.Attachment::isImage).findFirst();
 

--- a/src/main/java/org/enginehub/discord/util/PermissionRole.java
+++ b/src/main/java/org/enginehub/discord/util/PermissionRole.java
@@ -21,12 +21,30 @@
  */
 package org.enginehub.discord.util;
 
-public class PermissionRoles {
+import org.jetbrains.annotations.Nullable;
 
-    public static final String BOT_OWNER = "Owner";
-    public static final String ADMIN = "Admins";
-    public static final String MODERATOR = "Developers";
-    public static final String TRUSTED = "Verified";
-    public static final String ANY = "Everyone";
+public enum PermissionRole {
+    // Larger ordinal -> more permissions
+    ANY(null),
+    TRUSTED("Verified"),
+    PING_EXEMPT("Contributors"),
+    MODERATOR("Developers"),
+    ADMIN("Admins"),
+    BOT_OWNER(null),
+    ;
 
+    public static @Nullable PermissionRole fromDiscordRoleName(String name) {
+        for (PermissionRole role : values()) {
+            if (name.equalsIgnoreCase(role.discordRoleName)) {
+                return role;
+            }
+        }
+        return null;
+    }
+
+    private final String discordRoleName;
+
+    PermissionRole(String discordRoleName) {
+        this.discordRoleName = discordRoleName;
+    }
 }

--- a/src/main/java/org/enginehub/discord/util/command/CommandPermission.java
+++ b/src/main/java/org/enginehub/discord/util/command/CommandPermission.java
@@ -21,6 +21,7 @@
  */
 package org.enginehub.discord.util.command;
 
+import org.enginehub.discord.util.PermissionRole;
 import org.enginehub.piston.annotation.CommandCondition;
 
 import java.lang.annotation.Retention;
@@ -29,5 +30,5 @@ import java.lang.annotation.RetentionPolicy;
 @CommandCondition(CommandPermissionConditionGenerator.class)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CommandPermission {
-    String value();
+    PermissionRole value();
 }

--- a/src/main/java/org/enginehub/discord/util/command/PermissionCondition.java
+++ b/src/main/java/org/enginehub/discord/util/command/PermissionCondition.java
@@ -23,6 +23,7 @@ package org.enginehub.discord.util.command;
 
 import net.dv8tion.jda.api.entities.Member;
 import org.enginehub.discord.EngineHubBot;
+import org.enginehub.discord.util.PermissionRole;
 import org.enginehub.piston.Command;
 import org.enginehub.piston.inject.InjectedValueAccess;
 import org.enginehub.piston.inject.Key;
@@ -30,20 +31,15 @@ import org.enginehub.piston.inject.Key;
 public class PermissionCondition implements Command.Condition {
     private static final Key<Member> MEMBER_KEY = Key.of(Member.class);
 
-    private final String permission;
+    private final PermissionRole permission;
 
-    public PermissionCondition(String permission) {
+    public PermissionCondition(PermissionRole permission) {
         this.permission = permission;
-    }
-
-    public String getPermission() {
-        return permission;
     }
 
     @Override
     public boolean satisfied(InjectedValueAccess context) {
-        return permission == null || permission.isEmpty()
-            || context.injectedValue(MEMBER_KEY)
+        return permission == null || context.injectedValue(MEMBER_KEY)
             .map(member -> EngineHubBot.isAuthorised(member, permission))
             .orElse(false);
     }


### PR DESCRIPTION
Alert: permission roles are now inheritable, i.e. having `ADMIN` implies `TRUSTED` permissions.